### PR TITLE
Add getStaticProps at index to generate FAQs

### DIFF
--- a/src/components/Main/__snapshots__/test.tsx.snap
+++ b/src/components/Main/__snapshots__/test.tsx.snap
@@ -95,6 +95,12 @@ exports[`<Main /> should render the heading 1`] = `
   font-weight: 400;
 }
 
+.c2 a {
+  color: #FAFAFA;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c3 {
   margin-top: 3rem;
   width: min(30rem,100%);
@@ -116,7 +122,11 @@ exports[`<Main /> should render the heading 1`] = `
   <h2
     class="c2"
   >
-    Dúvidas e erros frequentes do curso de React Avançado e coisas relacionadas também.
+    <a
+      href="https://reactavancado.com.br/"
+    >
+      Dúvidas e erros frequentes do curso de React Avançado e coisas relacionadas também.
+    </a>
   </h2>
   <img
     alt="Um desenvolvedor de frente para uma tela com código."
@@ -189,4 +199,4 @@ exports[`<Main /> should render the heading 1`] = `
     </svg>
   </a>
 </main>
-`;
+`

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -2,37 +2,48 @@ import Link from 'next/link'
 import { Search as IconSearch } from '@styled-icons/material-outlined'
 import GithubCorner from 'react-github-corner'
 
+import { FaqProps } from 'lib/faqs'
+
 import Search from 'components/Search'
 
 import * as S from './styles'
 
+type MainProps = {
+  description?: string
+  faqs?: FaqProps[]
+}
+
 const Main = ({
-  description = 'Dúvidas e erros frequentes do curso de React Avançado e coisas relacionadas também.'
-}) => (
-  <S.Wrapper>
-    <S.Logo
-      src="/img/logo.svg"
-      alt="Imagem de um átomo e React Avançado escrito ao lado."
-    />
-    <S.Description>
-      <Link href="https://reactavancado.com.br/">
-        <a>{description}</a>
-      </Link>
-    </S.Description>
-    <S.Illustration
-      src="/img/hero-illustration.svg"
-      alt="Um desenvolvedor de frente para uma tela com código."
-    />
-    <S.InputWrapper>
-      <Search
-        name="search"
-        placeholder="Pesquisar"
-        type="text"
-        icon={<IconSearch />}
+  description = 'Dúvidas e erros frequentes do curso de React Avançado e coisas relacionadas também.',
+  faqs = []
+}: MainProps) => {
+  return (
+    <S.Wrapper>
+      <S.Logo
+        src="/img/logo.svg"
+        alt="Imagem de um átomo e React Avançado escrito ao lado."
       />
-    </S.InputWrapper>
-    <GithubCorner bannerColor="#F231A5" href="https://github.com/morpa/FAQ" />
-  </S.Wrapper>
-)
+      <S.Description>
+        <Link href="https://reactavancado.com.br/">
+          <a>{description}</a>
+        </Link>
+      </S.Description>
+      <S.Illustration
+        src="/img/hero-illustration.svg"
+        alt="Um desenvolvedor de frente para uma tela com código."
+      />
+      <S.InputWrapper>
+        <Search
+          name="search"
+          placeholder="Pesquisar"
+          type="text"
+          icon={<IconSearch />}
+          faqs={faqs}
+        />
+      </S.InputWrapper>
+      <GithubCorner bannerColor="#F231A5" href="https://github.com/morpa/FAQ" />
+    </S.Wrapper>
+  )
+}
 
 export default Main

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,12 +1,9 @@
-import { InputHTMLAttributes, useEffect, useState } from 'react'
+import { InputHTMLAttributes, useState } from 'react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { FaqProps } from 'lib/faqs'
 
 import * as S from './styles'
-
-type FaqsProps = {
-  slug: string
-}
 
 export type SearchProps = {
   onInput?: (value: string) => void
@@ -15,6 +12,7 @@ export type SearchProps = {
   initialValue?: string
   icon?: React.ReactNode
   iconPosition?: 'left' | 'right'
+  faqs: FaqProps[]
 } & InputHTMLAttributes<HTMLInputElement>
 
 const containerVariants = {
@@ -39,38 +37,26 @@ const Search = ({
   label,
   labelFor = '',
   initialValue = '',
+  faqs = [],
   onInput,
   ...props
 }: SearchProps) => {
   const [value, setValue] = useState(initialValue)
-  const [results, setResults] = useState([])
-  const [resultsSearch, setResultsSearchs] = useState([])
+  const [results, setResults] = useState<FaqProps[]>(faqs)
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.currentTarget.value
 
     setValue(newValue)
 
-    !!onInput && onInput(newValue)
-  }
-
-  useEffect(() => {
-    const allEndpoint = '/api/all'
-
-    fetch(allEndpoint)
-      .then((res) => res.json())
-      .then((res) => {
-        setResults(res.results)
-      })
-  }, [])
-
-  useEffect(() => {
-    setResultsSearchs(
-      results.filter((faq: FaqsProps) =>
-        faq.slug.toLowerCase().includes(value.toLowerCase())
+    setResults(
+      faqs.filter((faq: FaqProps) =>
+        faq.slug.toLowerCase().includes(newValue.toLowerCase())
       )
     )
-  }, [results, value])
+
+    !!onInput && onInput(newValue)
+  }
 
   return (
     <>
@@ -85,9 +71,9 @@ const Search = ({
           {...props}
         />
       </S.InputWrapper>
-      {resultsSearch && (
+      {results && (
         <S.ListWrapper>
-          {resultsSearch.map(({ slug, title }) => (
+          {results.map(({ slug, title }) => (
             <motion.div
               key={slug}
               variants={containerVariants}

--- a/src/lib/faqs.ts
+++ b/src/lib/faqs.ts
@@ -6,6 +6,12 @@ import html from 'remark-html'
 
 const faqsDirectory = path.join(process.cwd(), '_faqs')
 
+export type FaqProps = {
+  slug: string
+  title?: string
+  contentHtml?: string
+}
+
 export function getAllFaqsData() {
   const fileNames = fs.readdirSync(faqsDirectory)
   const allFaqsData = fileNames.map((fileName) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,19 @@
+import { InferGetStaticPropsType } from 'next'
 import Main from 'components/Main'
+import { getAllFaqsData, FaqProps } from 'lib/faqs'
 
-export default function Home() {
-  return <Main />
+export default function Home({
+  faqs
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return <Main faqs={faqs} />
+}
+
+export const getStaticProps = async () => {
+  const faqs: FaqProps[] = getAllFaqsData()
+
+  return {
+    props: {
+      faqs
+    }
+  }
 }


### PR DESCRIPTION
### Descripção

É adicionado o metodo **getStaticProps** na index para gerar o array de FAQs estaticamente. É passada a prop `faqs` desde o componente **Home** até o **Search**, onde é usada como valor inicial do estado `results`. Dessa maneira o useEffect com a chamada na api já não é requerido. Também o `setResults()` passa a ficar dentro do `onChange` do input de search.


Fixes #1