### PR TITLE
Add new styles support at FAQ page

### DIFF
--- a/src/pages/faqs/[slug].tsx
+++ b/src/pages/faqs/[slug].tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Container } from 'components/Container'
 import { getAllFaqsIds, getFaqData } from 'lib/faqs'
 
+import { ArrowBack } from '@styled-icons/material-outlined'
 import * as S from 'styles/faq-styles'
 
 type PostDataProps = {
@@ -21,17 +22,24 @@ type ParamsProps = {
 
 const Faq = ({ postData }: PostDataProps) => (
   <S.Wrapper>
-    <S.Logo
-      src="/img/logo.svg"
-      alt="Imagem de um átomo e React Avançado escrito ao lado."
-    />
+    <Link href="/">
+      <a>
+        <S.Logo
+          src="/img/logo.svg"
+          alt="Imagem de um átomo e React Avançado escrito ao lado."
+        />
+      </a>
+    </Link>
     <Head>
       <title>{postData.title}</title>
     </Head>
     <Container>
       <S.ArticleWrapper>
         <Link href="/">
-          <a>Voltar</a>
+          <S.BackLink>
+            <ArrowBack size={25} />
+            Voltar
+          </S.BackLink>
         </Link>
 
         <S.Title>{postData.title}</S.Title>

--- a/src/styles/faq-styles.ts
+++ b/src/styles/faq-styles.ts
@@ -27,20 +27,64 @@ export const Wrapper = styled.article`
 
 export const Logo = styled.img`
   width: 25rem;
-  margin-bottom: 5rem;
 `
 export const ArticleWrapper = styled.article`
   ${({ theme }) => css`
     background-color: ${theme.colors.lightBg};
     color: ${theme.colors.black};
     line-height: 2.8rem;
-    display: block;
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
     padding: 3rem;
+    margin-top: 5rem;
 
     p {
       word-break: break-word;
+    }
+
+    code {
+      font-size: ${theme.font.sizes.xlarge};
+      font-family: monospace;
+      font-weight: ${theme.font.bold};
+      background-color: ${theme.colors.lightGray};
+    }
+
+    pre {
+      background-color: ${theme.colors.black};
+      border-radius: ${theme.border.radius};
+      padding: ${theme.spacings.small};
+      margin: ${theme.spacings.xxsmall} 0;
+
+      & > code {
+        font-size: ${theme.font.sizes.medium};
+        font-family: monospace;
+        color: ${theme.colors.white};
+        background-color: transparent;
+      }
+    }
+
+    ul {
+      list-style: none;
+      margin: ${theme.spacings.xxsmall} 0;
+
+      & > li::before {
+        content: '\u2714';
+        font-size: ${theme.font.sizes.xlarge};
+        color: ${theme.colors.primary};
+        margin-right: ${theme.spacings.xxsmall};
+      }
+    }
+
+    ol {
+      margin: ${theme.spacings.xxsmall} 0;
+      position: relative;
+      left: ${theme.spacings.xsmall};
+
+      & > li::marker {
+        color: ${theme.colors.primary};
+        font-weight: ${theme.font.bold};
+      }
     }
   `}
 `
@@ -48,6 +92,13 @@ export const Title = styled.h1`
   ${({ theme }) => css`
     color: ${theme.colors.black};
     font-size: ${theme.font.sizes.xxlarge};
-    margin-bottom: ${theme.spacings.medium};
+    margin: ${theme.spacings.medium} 0;
+  `}
+`
+
+export const BackLink = styled.a`
+  ${({ theme }) => css`
+    font-size: ${theme.font.sizes.large};
+    cursor: pointer;
   `}
 `

--- a/src/styles/faq-styles.ts
+++ b/src/styles/faq-styles.ts
@@ -92,7 +92,8 @@ export const Title = styled.h1`
   ${({ theme }) => css`
     color: ${theme.colors.black};
     font-size: ${theme.font.sizes.xxlarge};
-    margin: ${theme.spacings.medium} 0;
+    margin-top: ${theme.spacings.xxsmall};
+    margin-bottom: ${theme.spacings.medium};
   `}
 `
 


### PR DESCRIPTION
Oi!, de novo eu 😆 ,

Eu fiquei brincando mais com o projeto e trago algumas modificações referentes ao estilos na pagina de FAQ, totalmente aberto a qualquer feedback/modificação. As mudanças são:

- Para deixar a pagina mais "amigavel" coloquei no logotipo um link para poder voltar na home, assim como um icone junto com a palavra voltar. Tambem apliquei mais espaçamento entre os elementos.

- Agora o article tem suporte de estilos para os elementos: `pre`, `code`, `ul`, `ol`

O que que voce acha?

### Screenshots

|Antes                    |Depois
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/99579218-a4c69400-29bc-11eb-894c-0feee3ba3259.png) | ![after](https://user-images.githubusercontent.com/50624358/99579236-aabc7500-29bc-11eb-8360-b77af6a76381.png)|