### PR TITLE
Fix elements width at FAQ layout

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -12,7 +12,7 @@ export type SearchProps = {
   initialValue?: string
   icon?: React.ReactNode
   iconPosition?: 'left' | 'right'
-  faqs: FaqProps[]
+  faqs?: FaqProps[]
 } & InputHTMLAttributes<HTMLInputElement>
 
 const containerVariants = {

--- a/src/styles/faq-styles.ts
+++ b/src/styles/faq-styles.ts
@@ -42,6 +42,7 @@ export const ArticleWrapper = styled.article`
 `
 export const Title = styled.h1`
   ${({ theme }) => css`
+    width: 100%;
     color: ${theme.colors.black};
     font-size: ${theme.font.sizes.xxlarge};
     margin-top: ${theme.spacings.xxsmall};
@@ -53,6 +54,9 @@ export const Title = styled.h1`
 
 export const Content = styled.div`
   ${({ theme }) => css`
+    width: 100%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
     code {
       font-size: ${theme.font.sizes.xlarge};
       font-family: monospace;


### PR DESCRIPTION
Prometo que é a ultima de hoje 🤣 

### Descripção
Força todos os elementos HTML de Title e Content a ter 100% de width (alguns não estavam pegando a largura completa do container). Também aplica o `break-word` no Title e no conteúdo (sem contar os elementos `pre`)

Finalmente também modifica a prop `faqs` para ser opcional, já que o Typescript estava reclamando de prop obrigatoria nos testes.

### Screenshots

|Antes                    |Depois
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/99597689-20cdd580-29d7-11eb-8407-c7df488e9951.png) | ![after](https://user-images.githubusercontent.com/50624358/99597703-26c3b680-29d7-11eb-9a06-bf11b58845a1.png) |
