### PR TITLE
Add Search accessibility with downshift and router progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,19 @@
   },
   "dependencies": {
     "@styled-icons/material-outlined": "^10.18.0",
+    "downshift": "^6.0.6",
     "framer-motion": "^2.9.4",
     "gray-matter": "^4.0.2",
     "next": "^10.0.1",
     "next-pwa": "^3.1.4",
+    "nprogress": "^0.2.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-github-corner": "^2.5.0",
     "remark": "^13.0.0",
     "remark-html": "^13.0.1",
-    "styled-components": "5.2.1"
+    "styled-components": "5.2.1",
+    "styled-media-query": "^2.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -48,6 +51,7 @@
     "@testing-library/user-event": "^12.2.0",
     "@types/jest": "^26.0.13",
     "@types/node": "^14.14.7",
+    "@types/nprogress": "^0.2.0",
     "@types/react": "^16.9.56",
     "@types/styled-components": "^5.1.3",
     "@typescript-eslint/eslint-plugin": "^4.1.1",

--- a/src/components/Main/__snapshots__/test.tsx.snap
+++ b/src/components/Main/__snapshots__/test.tsx.snap
@@ -21,6 +21,7 @@ exports[`<Main /> should render the heading 1`] = `
 
 .c5:focus-within {
   box-shadow: 0 0 0.5rem #F231A5;
+  border-color: #F231A5;
 }
 
 .c8 {
@@ -59,6 +60,19 @@ exports[`<Main /> should render the heading 1`] = `
   padding: 0;
   left: 0;
   right: 0;
+}
+
+.c10 {
+  font-size: 1.4rem;
+  font-style: italic;
+  font-weight: 300;
+  color: #EAEAEA;
+  text-align: left;
+}
+
+.c10 span {
+  color: #3CD3C1;
+  font-weight: 600;
 }
 
 .c0 {
@@ -107,8 +121,14 @@ exports[`<Main /> should render the heading 1`] = `
 }
 
 .c4 {
-  width: 60%;
+  width: 100%;
   margin-top: 3rem;
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 70%;
+  }
 }
 
 <main
@@ -137,7 +157,11 @@ exports[`<Main /> should render the heading 1`] = `
     class="c4"
   >
     <div
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-owns="faq-autosuggest-menu"
       class="c5"
+      role="combobox"
     >
       <div
         class="c6"
@@ -160,16 +184,32 @@ exports[`<Main /> should render the heading 1`] = `
         </svg>
       </div>
       <input
+        aria-autocomplete="list"
+        aria-controls="faq-autosuggest-menu"
+        aria-label="Procure entre perguntas mais frequentes"
+        aria-labelledby="faq-autosuggest-label"
+        autocomplete="off"
         class="c8"
-        name="search"
+        id="faq-autosuggest-input"
         placeholder="Pesquisar"
         type="text"
         value=""
       />
     </div>
     <ul
+      aria-labelledby="faq-autosuggest-label"
       class="c9"
-    />
+      id="faq-autosuggest-menu"
+      role="listbox"
+    >
+      <li
+        class="c10"
+      >
+        Nenhum resultado encontrado para 
+         
+        <span />
+      </li>
+    </ul>
   </div>
   <a
     aria-label="Open GitHub project"

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -34,9 +34,8 @@ const Main = ({
       />
       <S.InputWrapper>
         <Search
-          name="search"
+          aria-label="Procure entre perguntas mais frequentes"
           placeholder="Pesquisar"
-          type="text"
           icon={<IconSearch />}
           faqs={faqs}
         />

--- a/src/components/Main/styles.ts
+++ b/src/components/Main/styles.ts
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components'
+import media from 'styled-media-query'
 
 export const Wrapper = styled.main`
   ${({ theme }) => css`
@@ -38,6 +39,10 @@ export const Illustration = styled.img`
 `
 
 export const InputWrapper = styled.div`
-  width: 60%;
+  width: 100%;
   margin-top: 3rem;
+
+  ${media.greaterThan('medium')`
+    width: 70%;
+  `}
 `

--- a/src/components/Search/mock.ts
+++ b/src/components/Search/mock.ts
@@ -1,0 +1,5 @@
+export default [
+  { slug: 'faq-1', title: 'Primeiro' },
+  { slug: 'faq-2', title: 'Segundo' },
+  { slug: 'faq-3', title: 'Terceiro' }
+]

--- a/src/components/Search/styles.ts
+++ b/src/components/Search/styles.ts
@@ -1,4 +1,5 @@
-import styled, { css } from 'styled-components'
+import styled, { css, DefaultTheme } from 'styled-components'
+import { darken } from 'polished'
 
 import { SearchProps } from '.'
 
@@ -15,6 +16,7 @@ export const InputWrapper = styled.div`
 
     &:focus-within {
       box-shadow: 0 0 0.5rem ${theme.colors.primary};
+      border-color: ${theme.colors.primary};
     }
   `}
 `
@@ -53,6 +55,7 @@ export const Icon = styled.div<IconPositionProps>`
     }
   `}
 `
+
 export const ListWrapper = styled.ul`
   ${({ theme }) => css`
     list-style: none;
@@ -64,25 +67,49 @@ export const ListWrapper = styled.ul`
     right: 0;
   `}
 `
+export const ListItem = styled.li``
 
-export const ListItem = styled.li`
+export const ListItemNotFound = styled.li`
   ${({ theme }) => css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 0.2rem;
-    background: ${theme.colors.primary};
-    margin: 0 0 ${theme.spacings.xxsmall};
-    padding: ${theme.spacings.xxsmall};
+    font-size: ${theme.font.sizes.small};
+    font-style: italic;
+    font-weight: ${theme.font.light};
+    color: ${theme.colors.lightGray};
+    text-align: left;
 
-    a {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      text-decoration: none;
-      color: ${theme.colors.white};
-      width: fit-content;
-      height: fit-content;
+    span {
+      color: ${theme.colors.secondary};
+      font-weight: ${theme.font.bold};
     }
+  `}
+`
+
+type AnchorProps = {
+  highlighted?: boolean
+}
+
+const anchorModifiers = {
+  highlighted: (theme: DefaultTheme) => css`
+    background: ${darken(0.15, theme.colors.primary)};
+    padding-left: ${theme.spacings.small};
+    border-left: 0.4rem solid ${darken(0.1, theme.colors.secondary)};
+  `
+}
+
+export const Anchor = styled.a<AnchorProps>`
+  ${({ theme, highlighted }) => css`
+    display: block;
+    color: ${theme.colors.white};
+    background: ${theme.colors.primary};
+    margin-bottom: 0.3rem;
+    padding: ${theme.spacings.xxsmall} ${theme.spacings.xsmall};
+    transition: ${theme.transition.fast};
+    text-decoration: none;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    ${highlighted && anchorModifiers.highlighted(theme)}
   `}
 `

--- a/src/components/Search/test.tsx
+++ b/src/components/Search/test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Email } from '@styled-icons/material-outlined'
 
@@ -6,17 +6,21 @@ import { renderWithTheme } from 'utils/tests/helpers'
 
 import Search from '.'
 
+import faqs from './mock'
+
 describe('<Search />', () => {
   it('Renders with Label', () => {
-    renderWithTheme(<Search label="Label" labelFor="Field" id="Field" />)
+    renderWithTheme(<Search label="label" />)
 
-    expect(screen.getByLabelText('Label')).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'label' })).toBeInTheDocument()
   })
 
   it('Renders without Label', () => {
     renderWithTheme(<Search />)
 
-    expect(screen.queryByLabelText('Label')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('textbox', { name: 'label' })
+    ).not.toBeInTheDocument()
   })
 
   it('Renders with placeholder', () => {
@@ -39,13 +43,54 @@ describe('<Search />', () => {
     expect(screen.getByTestId('icon').parentElement).toHaveStyle({ order: 1 })
   })
 
-  it('Is accessible by tab', () => {
-    renderWithTheme(<Search label="Search" labelFor="Search" id="Search" />)
+  it('should be focused by default', () => {
+    renderWithTheme(<Search label="Search" id="Search" />)
 
-    const input = screen.getByLabelText('Search')
-    expect(document.body).toHaveFocus()
-
-    userEvent.tab()
+    const input = screen.getByRole('textbox', { name: /search/i })
     expect(input).toHaveFocus()
+  })
+
+  it('should render all results by default', () => {
+    renderWithTheme(<Search faqs={faqs} />)
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('should highlight first element on ArrowDown', async () => {
+    renderWithTheme(<Search faqs={faqs} />)
+
+    const firstElement = screen.getByText('Primeiro')
+
+    expect(firstElement).toHaveStyle({
+      paddingLeft: '1.6rem',
+      background: '#F231A5'
+    })
+
+    const input = screen.getByRole('textbox')
+
+    fireEvent.keyDown(input, { key: 'ArrowDown', which: 40, keyCode: 40 })
+
+    expect(firstElement).toHaveStyle({
+      paddingLeft: '2.4rem',
+      background: '#CA0D7E'
+    })
+  })
+
+  it('should show a message when results not found', async () => {
+    renderWithTheme(<Search faqs={faqs} />)
+
+    const input = screen.getByRole('textbox')
+
+    const text = 'test'
+
+    userEvent.type(input, text)
+
+    await waitFor(() => {
+      expect(input).toHaveValue(text)
+      expect(
+        screen.getByText(/nenhum resultado encontrado para/i)
+      ).toBeInTheDocument()
+      expect(screen.getByText(/test/i)).toBeInTheDocument()
+    })
   })
 })

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,23 @@ import { ThemeProvider } from 'styled-components'
 import GlobalStyles from 'styles/global'
 import theme from 'styles/theme'
 
+import { Router } from 'next/router'
+import NProgress from 'nprogress'
+
+NProgress.configure({ showSpinner: false })
+
+Router.events.on('routeChangeStart', () => {
+  NProgress.start()
+})
+
+Router.events.on('routeChangeComplete', () => {
+  NProgress.done()
+})
+
+Router.events.on('routeChangeError', () => {
+  NProgress.done()
+})
+
 function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>

--- a/src/styles/faq-styles.ts
+++ b/src/styles/faq-styles.ts
@@ -57,11 +57,17 @@ export const Content = styled.div`
     width: 100%;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    h3 {
+      font-size: ${theme.font.sizes.xlarge};
+      margin: ${theme.spacings.xsmall} 0;
+    }
     code {
       font-size: ${theme.font.sizes.xlarge};
       font-family: monospace;
       font-weight: ${theme.font.bold};
-      background-color: ${theme.colors.lightGray};
+      padding: 0 0.4rem;
+      margin: 0 0.2rem;
+      background-color: #d1d5db;
     }
 
     pre {
@@ -75,6 +81,7 @@ export const Content = styled.div`
 
       & > code {
         font-size: ${theme.font.sizes.medium};
+        font-weight: ${theme.font.light};
         font-family: monospace;
         color: ${theme.colors.white};
         background-color: transparent;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -68,6 +68,88 @@ const GlobalStyles: GlobalStyleComponent<
         background-color: ${theme.colors.mainBg};
       `}
     }
+
+    #nprogress {
+      pointer-events: none;
+    }
+
+    #nprogress .bar {
+      background: ${theme.colors.secondary};
+
+      position: fixed;
+      z-index: 1031;
+      top: 0;
+      left: 0;
+
+      width: 100%;
+      height: 2px;
+    }
+
+    /* Fancy blur effect */
+    #nprogress .peg {
+      display: block;
+      position: absolute;
+      right: 0px;
+      width: 100px;
+      height: 100%;
+      box-shadow: 0 0 10px ${theme.colors.secondary},
+        0 0 5px ${theme.colors.secondary};
+      opacity: 1;
+
+      -webkit-transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+      transform: rotate(3deg) translate(0px, -4px);
+    }
+
+    /** NProgress */
+    #nprogress .spinner {
+      display: block;
+      position: fixed;
+      z-index: 1031;
+      top: 15px;
+      right: 15px;
+    }
+
+    #nprogress .spinner-icon {
+      width: 18px;
+      height: 18px;
+      box-sizing: border-box;
+
+      border: solid 2px transparent;
+      border-top-color: ${theme.colors.secondary};
+      border-left-color: ${theme.colors.secondary};
+      border-radius: 50%;
+
+      -webkit-animation: nprogress-spinner 400ms linear infinite;
+      animation: nprogress-spinner 400ms linear infinite;
+    }
+
+    .nprogress-custom-parent {
+      overflow: hidden;
+      position: relative;
+    }
+
+    .nprogress-custom-parent #nprogress .spinner,
+    .nprogress-custom-parent #nprogress .bar {
+      position: absolute;
+    }
+
+    @-webkit-keyframes nprogress-spinner {
+      0% {
+        -webkit-transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+      }
+    }
+    @keyframes nprogress-spinner {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
   `}
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,11 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==
 
+"@types/nprogress@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/nprogress/-/nprogress-0.2.0.tgz#86c593682d4199212a0509cc3c4d562bbbd6e45f"
+  integrity sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==
+
 "@types/overlayscrollbars@^1.9.0":
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz#98456caceca8ad73bd5bb572632a585074e70764"
@@ -5024,6 +5029,11 @@ compose-function@3.0.3:
   dependencies:
     arity-n "^1.0.4"
 
+compute-scroll-into-view@^1.0.14:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz#5b7bf4f7127ea2c19b750353d7ce6776a90ee088"
+  integrity sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -5933,6 +5943,16 @@ dotenv@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+downshift@^6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.0.6.tgz#82aee8e2e260d7ad99df8a0969bd002dd523abe8"
+  integrity sha512-tmLab3cXCn6PtZYl9V8r/nB2m+7/nCNrwo0B3kTHo/2lRBHr+1en1VNOQt2wIt0ajanAnxquZ00WPCyxe6cNFQ==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    compute-scroll-into-view "^1.0.14"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 duplexer@^0.1.1:
   version "0.1.2"
@@ -10238,6 +10258,11 @@ npmlog@^4.0.1, npmlog@^4.1.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nprogress@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
+  integrity sha1-y480xTIT2JVyP8urkH6UIq28r7E=
+
 nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
@@ -11489,7 +11514,7 @@ react-inspector@^5.0.1:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13056,6 +13081,11 @@ styled-jsx@3.3.1:
     string-hash "1.1.3"
     stylis "3.5.4"
     stylis-rule-sheet "0.0.10"
+
+styled-media-query@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/styled-media-query/-/styled-media-query-2.1.2.tgz#d59e8d91bc4bcff210dc511bdcecedf16eb2c5b7"
+  integrity sha512-ds24iBxOrfIhdHP+e23y6kj1gbosgWu+tgAuxvMrYmnp6Sju/LjuY8lfkiVnn6P7mcdhtwpC2Z43o+apT9UdJg==
 
 stylis-rule-sheet@0.0.10:
   version "0.0.10"


### PR DESCRIPTION
Hey @Morpa!, tudo bem? 

Fiquei brincando com o projeto, e trouxe algumas mudanças que podem ser interesantes. Se voce puder, da uma olhada na Preview e diga-me se gostou, coisas que voce mudaria, etc. Qualquer feedback é bem vindo!

### Dropdown
- Usando [downshift](https://github.com/downshift-js/downshift), mudei o dropdown para fazer uso do hook [useCombobox](https://www.downshift-js.com/use-combobox). Assim ele passa a ser totalmente acessible (ArrowDown, ArrowUp, Enter, Mouseover).
- Os itens continuan sendo Links, mas agora o bloco inteiro fazendo possivel fazer click em qualquer para navegar. Também quando um dos elementos é selecionado, se apertar `Enter` é usado um Router.push do Next para navegar pro `faq`.
- O componente search já não precissa da prop `labelFor`, já que passa a ser gerenciado pelo hook.

### Estilos

- Mudei o alignment do texto para ficar na esquerda. Achei que seria mais fácil para a leitura ter os textos começando no mesmo ponto.
- Coloquei cada elemento em uma linha só. Caso algum titulo seja cortado pela ellipsis, o elemento `a` tem o atributo `title` fazendo possivel ler o titulo inteiro se passar o mouse por cima.
- Também coloquei uma media-query para usar o 100% do width em dispositivos mais pequenos.
- Adicionei uma progress bar no topo da página para mostrar o status da mudança de página.

