### PR TITLE
Fix border-radius for input and items

### DIFF
--- a/src/components/Main/__snapshots__/test.tsx.snap
+++ b/src/components/Main/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<Main /> should render the heading 1`] = `
   display: -ms-flexbox;
   display: flex;
   background: #EAEAEA;
-  border-radius: 0.2rem;
+  border-radius: 0.4rem;
   padding: 0 1.6rem;
   border: 0.2rem solid;
   border-color: #EAEAEA;

--- a/src/components/Search/styles.ts
+++ b/src/components/Search/styles.ts
@@ -9,7 +9,7 @@ export const InputWrapper = styled.div`
   ${({ theme }) => css`
     display: flex;
     background: ${theme.colors.lightGray};
-    border-radius: 0.2rem;
+    border-radius: ${theme.border.radius};
     padding: 0 ${theme.spacings.xsmall};
     border: 0.2rem solid;
     border-color: ${theme.colors.lightGray};
@@ -103,6 +103,7 @@ export const Anchor = styled.a<AnchorProps>`
     background: ${theme.colors.primary};
     margin-bottom: 0.3rem;
     padding: ${theme.spacings.xxsmall} ${theme.spacings.xsmall};
+    border-radius: ${theme.border.radius};
     transition: ${theme.transition.fast};
     text-decoration: none;
     text-align: left;


### PR DESCRIPTION
Adiciona um border-radius padrão do `theme` para o input de búsqueda e os items do dropdown.